### PR TITLE
make slurm_submit.sh working correclty with "WholeNodes = False; HostNumber = 1; CPUNumber = 8"

### DIFF
--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -82,15 +82,11 @@ if [ "x$bls_opt_wholenodes" == "xyes" ] ; then
     fi
   fi
 else
+  echo "#$slurm_opt_prefix -n $bls_opt_mpinodes" >> $bls_tmp_file
   if [[ ! -z "$bls_opt_smpgranularity" ]] ; then
-    echo "#$slurm_opt_prefix -n $bls_opt_mpinodes" >> $bls_tmp_file
     echo "#$slurm_opt_prefix --ntasks-per-node $bls_opt_smpgranularity" >> $bls_tmp_file
-  else
-    if [[ ! -z "$bls_opt_hostnumber" ]] ; then
-      echo "#$slurm_opt_prefix -N $bls_opt_hostnumber" >> $bls_tmp_file
-    elif [[ $bls_opt_mpinodes -gt 0 ]] ; then
-      echo "#$slurm_opt_prefix -n $bls_opt_mpinodes" >> $bls_tmp_file
-    fi
+  elif [[ ! -z "$bls_opt_hostnumber" ]] ; then
+    echo "#$slurm_opt_prefix -N $bls_opt_hostnumber" >> $bls_tmp_file
   fi
 fi
 # --- End of MPI directives


### PR DESCRIPTION
The latest version of the slurm_submit.sh script doesn't work correctly with the multi-core jobs submitted by the CMS VO. These jobs have the following parameters in their JDL files: "WholeNodes = False; HostNumber = 1; CPUNumber = 8". All other *_submit.sh scripts work with these parameters. This pull request fixes the slurm_submit.sh script.
